### PR TITLE
Updates for latest ansible version

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,11 +2,11 @@
 - import_tasks: preflight.yml
 
 - name: fqdn | Configure Debian
-  ansible.builtin.include: debian.yml
+  ansible.builtin.include_tasks: debian.yml
   when: ansible_os_family == 'Debian'
 
 - name: fqdn | Configure Redhat
-  ansible.builtin.include: redhat.yml
+  ansible.builtin.include_tasks: redhat.yml
   when: ansible_os_family == 'RedHat'
 
 - name: Install loki


### PR DESCRIPTION
The most recent ansible version deprecates the `ansible.builtin.include` module, and uses `ansible.builtin.include_tasks` instead. I've updated that in the role and tested it :)